### PR TITLE
fix: segmentation limit

### DIFF
--- a/hypervisor/src/intel/segmentation.rs
+++ b/hypervisor/src/intel/segmentation.rs
@@ -147,7 +147,7 @@ impl SegmentDescriptor {
 
             // Extract segment limit from the descriptor.
             let segment_limit_low = entry_value.get_bits(0..16);
-            let segment_limit_high = entry_value.get_bits(48..52) << 12;
+            let segment_limit_high = entry_value.get_bits(48..52) << 16;
             let mut segment_limit = segment_limit_low | segment_limit_high;
 
             // For non-user segments (like TSS), the base address can span two GDT entries.


### PR DESCRIPTION
Invalid shift results in segment limit of 0xfff_ffff instead of 0xffff_ffff. This causes 32 bit processes (like Discord and Steam) to crash. See this for the fix: https://github.com/rcore-os/RVM1.5/blob/d317825d748c6530144eaf5d758afa5c76c32232/src/arch/x86_64/segmentation.rs#L101